### PR TITLE
CF-727 wrong templates

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -149,7 +149,7 @@ module.exports = BaseView = Backbone.View.extend({
    * Get template function
    */
   getTemplate: function() {
-    return this.app.templateAdapter.getTemplate(this.getTemplateName());
+    return this.app.templateAdapter.getTemplate(this.getTemplateName(), {app: this.app});
   },
 
   /**


### PR DESCRIPTION
Pass in app context to the getTemplates function so rendrer can grab req specific app data.